### PR TITLE
Replace WebClient with HttpClient in order to allow concurrent access

### DIFF
--- a/CSharpOsu/CSharpOsu.cs
+++ b/CSharpOsu/CSharpOsu.cs
@@ -10,6 +10,7 @@ using CSharpOsu.Util.Enums;
 using CSharpOsu.Util.Strings;
 using CSharpOsu.Module;
 using System.IO;
+using System.Net.Http;
 using CSharpOsu.Util;
 
 [assembly: CLSCompliant(true)]
@@ -18,7 +19,7 @@ namespace CSharpOsu
     public class OsuClient
     {
         Strings str = new Strings();
-        static WebClient client = new WebClient();
+        static HttpClient client = new HttpClient();
         Utility utl;
 
         /// <summary>
@@ -27,14 +28,14 @@ namespace CSharpOsu
         /// <param name="key">API Key</param>
         /// <param name="_throwIfNull"> If the returned objects is null then throw error. By default is set on false.</param>
         /// <param name="webClient">Specify a WebClient to use. Default null, will use internal WebClient.</param>
-        public OsuClient(string key,WebClient? webClient= null, bool _throwIfNull= false)
+        public OsuClient(string key,HttpClient? httpClient= null, bool _throwIfNull= false)
         {
             str.Key = key;
-            if (webClient == null)
+            if (httpClient == null)
             {
                 utl = new Utility(client, _throwIfNull);
             }
-            else { utl = new Utility(webClient, _throwIfNull); }
+            else { utl = new Utility(httpClient, _throwIfNull); }
         }
 
         /// <summary>

--- a/CSharpOsu/CSharpOsu.cs
+++ b/CSharpOsu/CSharpOsu.cs
@@ -27,7 +27,7 @@ namespace CSharpOsu
         /// </summary>
         /// <param name="key">API Key</param>
         /// <param name="_throwIfNull"> If the returned objects is null then throw error. By default is set on false.</param>
-        /// <param name="webClient">Specify a WebClient to use. Default null, will use internal WebClient.</param>
+        /// <param name="httpClient">Specify a HttpClient to use. Default null, will use internal HttpClient.</param>
         public OsuClient(string key,HttpClient? httpClient= null, bool _throwIfNull= false)
         {
             str.Key = key;

--- a/CSharpOsu/Util/Utility.cs
+++ b/CSharpOsu/Util/Utility.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Web;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,15 +14,15 @@ namespace CSharpOsu.Util
 {
     internal class Utility
     {
-        WebClient client;
+        HttpClient client;
         private bool throwIfNull;
 
-        public Utility(WebClient? _client, bool _throwIfNull) { client = _client; throwIfNull = _throwIfNull; }
+        public Utility(HttpClient? _client, bool _throwIfNull) { client = _client; throwIfNull = _throwIfNull; }
         public string GetUrl(string url)
         {
             try
             {
-                var json = client.DownloadString(url);
+                var json = client.GetAsync(url).Result.Content.ReadAsStringAsync().Result;
                 if (throwIfNull)
                     if (json == "[]") { throw new Exception("No objects have been found for those arguments"); }
                 return json;


### PR DESCRIPTION
With current implementation when you attempt to retrieve data from multiple threads at once, WebClient breaks with exception saying `WebClient does not support concurrent I/O operations`.

This change makes it so it is possible to access same OsuClient instance Get methods from several threads at once.